### PR TITLE
Adds some inspection of the table cookies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 21.0.4
-elixir 1.7.1
+erlang 21.2.3
+elixir 1.7.4-otp-21

--- a/lib/mnesiac.ex
+++ b/lib/mnesiac.ex
@@ -3,7 +3,7 @@ defmodule Mnesiac do
   Mnesiac Manager
   """
   require Logger
-  alias Mnesiac.Store
+  alias Mnesiac.StoreManager
 
   @doc """
   Start Mnesia with/without a cluster
@@ -29,9 +29,9 @@ defmodule Mnesiac do
   def start do
     with :ok <- ensure_dir_exists(),
          :ok <- ensure_started(),
-         :ok <- Store.copy_schema(Node.self()),
-         :ok <- Store.init_tables(),
-         :ok <- Store.ensure_tables_loaded() do
+         :ok <- StoreManager.copy_schema(Node.self()),
+         :ok <- StoreManager.init_tables(),
+         :ok <- StoreManager.ensure_tables_loaded() do
       :ok
     else
       {:error, reason} ->
@@ -46,12 +46,12 @@ defmodule Mnesiac do
   def join_cluster(cluster_node) do
     with :ok <- ensure_dir_exists(),
          :ok <- ensure_stopped(),
-         :ok <- Store.delete_schema(),
+         :ok <- StoreManager.delete_schema(),
          :ok <- ensure_started(),
          :ok <- connect(cluster_node),
-         :ok <- Store.copy_schema(Node.self()),
-         :ok <- Store.copy_tables(),
-         :ok <- Store.ensure_tables_loaded() do
+         :ok <- StoreManager.copy_schema(Node.self()),
+         :ok <- StoreManager.copy_tables(cluster_node),
+         :ok <- StoreManager.ensure_tables_loaded() do
       :ok
     else
       {:error, reason} ->

--- a/lib/mnesiac/store.ex
+++ b/lib/mnesiac/store.ex
@@ -15,7 +15,7 @@ defmodule Mnesiac.Store do
 
   @callback resolve_conflict(node()) :: term
 
-  @optional_callbacks copy_store: 0, init_store: 0, resolve_confict: 1
+  @optional_callbacks copy_store: 0, init_store: 0, resolve_conflict: 1
 
   defmacro __using__(_) do
     quote do

--- a/lib/mnesiac/store.ex
+++ b/lib/mnesiac/store.ex
@@ -41,6 +41,9 @@ defmodule Mnesiac.Store do
       end
 
       def resolve_conflict(cluster_node) do
+        Logger.info(fn ->
+          "[mnesiac:#{Node.self()}] #{inspect(data_mapper)}: data found on both sides, copy aborted."
+        end)
         :ok
       end
 

--- a/lib/mnesiac/store.ex
+++ b/lib/mnesiac/store.ex
@@ -1,104 +1,43 @@
 defmodule Mnesiac.Store do
-  @moduledoc """
-  Mnesia Store Manager
-  """
-
   @doc """
-  Init tables
-  """
-  def init_tables do
-    case :mnesia.system_info(:extra_db_nodes) do
-      [] ->
-        create_tables()
+  This function returns ths store's configuration as a keyword list.
+  For more information on the options supported here, see mnesia's documenatation.
 
-      [_head | _tail] ->
-        copy_tables()
+  ## Examples
+  iex> store_options()
+  [attributes: [...], index: [:topic_id], disc_copies: [Node.self()]]
+  """
+  @callback store_options() :: term
+
+  @callback copy_store() :: atom
+
+  @callback init_store() :: term
+
+  @optional_callbacks copy_store: 0, init_store: 0
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour Mnesiac.Store
+      @doc """
+      Mnesiac will call this method to initialize the table
+      """
+      def init_store do
+        :mnesia.create_table(__MODULE__, store_options())
+      end
+
+      @doc """
+      Mnesiac will call this method to copy the table
+      """
+      def copy_store do
+        for type <- [:ram_copies, :disc_copies, :disc_only_copies] do
+          value = Keyword.get(store_options(), type, [])
+          if Enum.member?(value, Node.self()) do
+            :mnesia.add_table_copy(__MODULE__, Node.self(), type)
+          end
+        end
+      end
+
+      defoverridable Mnesiac.Store
     end
-  end
-
-  @doc """
-  Ensure tables loaded
-  """
-  def ensure_tables_loaded do
-    tables = :mnesia.system_info(:local_tables)
-
-    case :mnesia.wait_for_tables(tables, table_load_timeout()) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        {:error, reason}
-
-      {:timeout, bad_tables} ->
-        {:error, {:timeout, bad_tables}}
-    end
-  end
-
-  @doc """
-  Create tables
-  """
-  def create_tables do
-    Enum.each(stores(), fn data_mapper ->
-      apply(data_mapper, :init_store, [])
-    end)
-
-    :ok
-  end
-
-  @doc """
-  Copy tables
-  """
-  def copy_tables do
-    Enum.each(stores(), fn data_mapper ->
-      apply(data_mapper, :copy_store, [])
-    end)
-
-    :ok
-  end
-
-  @doc """
-  Copy schema
-  """
-  def copy_schema(cluster_node) do
-    copy_type = Application.get_env(:mnesiac, :schema_type, :ram_copies)
-
-    case :mnesia.change_table_copy_type(:schema, cluster_node, copy_type) do
-      {:atomic, :ok} ->
-        :ok
-
-      {:aborted, {:already_exists, :schema, _, _}} ->
-        :ok
-
-      {:aborted, reason} ->
-        {:error, reason}
-    end
-  end
-
-  @doc """
-  Delete schema
-  """
-  def delete_schema do
-    :mnesia.delete_schema([Node.self()])
-  end
-
-  @doc """
-  Delete schema copy
-  """
-  def del_schema_copy(cluster_node) do
-    case :mnesia.del_table_copy(:schema, cluster_node) do
-      {:atomic, :ok} ->
-        :ok
-
-      {:aborted, reason} ->
-        {:error, reason}
-    end
-  end
-
-  defp stores do
-    Application.get_env(:mnesiac, :stores)
-  end
-
-  defp table_load_timeout do
-    Application.get_env(:mnesiac, :table_load_timeout, 600_000)
   end
 end

--- a/lib/mnesiac/store.ex
+++ b/lib/mnesiac/store.ex
@@ -13,6 +13,8 @@ defmodule Mnesiac.Store do
 
   @callback init_store() :: term
 
+  @callback resolve_conflict(cluster_node) :: term
+
   @optional_callbacks copy_store: 0, init_store: 0
 
   defmacro __using__(_) do
@@ -31,10 +33,15 @@ defmodule Mnesiac.Store do
       def copy_store do
         for type <- [:ram_copies, :disc_copies, :disc_only_copies] do
           value = Keyword.get(store_options(), type, [])
+
           if Enum.member?(value, Node.self()) do
             :mnesia.add_table_copy(__MODULE__, Node.self(), type)
           end
         end
+      end
+
+      def resolve_conflict(cluster_node) do
+        :ok
       end
 
       defoverridable Mnesiac.Store

--- a/lib/mnesiac/store.ex
+++ b/lib/mnesiac/store.ex
@@ -15,7 +15,7 @@ defmodule Mnesiac.Store do
 
   @callback resolve_conflict(node()) :: term
 
-  @optional_callbacks copy_store: 0, init_store: 0
+  @optional_callbacks copy_store: 0, init_store: 0, resolve_confict: 1
 
   defmacro __using__(_) do
     quote do

--- a/lib/mnesiac/store.ex
+++ b/lib/mnesiac/store.ex
@@ -13,7 +13,7 @@ defmodule Mnesiac.Store do
 
   @callback init_store() :: term
 
-  @callback resolve_conflict(cluster_node) :: term
+  @callback resolve_conflict(node()) :: term
 
   @optional_callbacks copy_store: 0, init_store: 0
 

--- a/lib/mnesiac/store_manager.ex
+++ b/lib/mnesiac/store_manager.ex
@@ -1,0 +1,128 @@
+defmodule Mnesiac.StoreManager do
+  @moduledoc """
+  Mnesia Store Manager
+  """
+
+  require Logger
+
+  @doc """
+  Init tables
+  """
+  def init_tables do
+    case :mnesia.system_info(:extra_db_nodes) do
+      [] ->
+        create_tables()
+
+      [head | _tail] ->
+        copy_tables(head)
+    end
+  end
+
+  @doc """
+  Ensure tables loaded
+  """
+  def ensure_tables_loaded do
+    tables = :mnesia.system_info(:local_tables)
+
+    case :mnesia.wait_for_tables(tables, table_load_timeout()) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+
+      {:timeout, bad_tables} ->
+        {:error, {:timeout, bad_tables}}
+    end
+  end
+
+  @doc """
+  Create tables
+  """
+  def create_tables do
+    Enum.each(stores(), fn data_mapper ->
+      apply(data_mapper, :init_store, [])
+    end)
+
+    :ok
+  end
+
+  @doc """
+  Copy tables
+  """
+  def copy_tables(cluster_node) do
+    local_cookies = get_table_cookies()
+    remote_cookies = get_table_cookies(cluster_node)
+
+    Enum.each(stores(), fn data_mapper ->
+      case {local_cookies[data_mapper], remote_cookies[data_mapper]} do
+        {nil, nil} ->
+          apply(data_mapper, :init_store, [])
+        {nil, _} ->
+          apply(data_mapper, :copy_store, [])
+        {_, nil} ->
+          Logger.info(fn -> "[mnesiac:#{Node.self()}] #{inspect(data_mapper)}: no remote data to copy found." end)
+          {:error, :no_remote_data_to_copy}
+        {_local, _remote} ->
+          Logger.info(fn -> "[mnesiac:#{Node.self()}] #{inspect(data_mapper)}: data found on both sides, copy aborted." end)
+          {:error, :data_conflict}
+      end
+    end)
+
+    :ok
+  end
+
+  @doc """
+  Copy schema
+  """
+  def copy_schema(cluster_node) do
+    copy_type = Application.get_env(:mnesiac, :schema_type, :ram_copies)
+
+    case :mnesia.change_table_copy_type(:schema, cluster_node, copy_type) do
+      {:atomic, :ok} ->
+        :ok
+
+      {:aborted, {:already_exists, :schema, _, _}} ->
+        :ok
+
+      {:aborted, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Delete schema
+  """
+  def delete_schema do
+    :mnesia.delete_schema([Node.self()])
+  end
+
+  @doc """
+  Delete schema copy
+  """
+  def del_schema_copy(cluster_node) do
+    case :mnesia.del_table_copy(:schema, cluster_node) do
+      {:atomic, :ok} ->
+        :ok
+
+      {:aborted, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp stores do
+    Application.get_env(:mnesiac, :stores)
+  end
+
+  defp table_load_timeout do
+    Application.get_env(:mnesiac, :table_load_timeout, 600_000)
+  end
+
+  def get_table_cookies(node \\ Node.self()) do
+    tables = :rpc.call(node, :mnesia, :system_info, [:tables])
+
+    Enum.reduce(tables, %{}, fn t, acc ->
+      Map.put(acc, t, :rpc.call(node, :mnesia, :table_info, [t, :cookie]))
+    end)
+  end
+end

--- a/lib/mnesiac/store_manager.ex
+++ b/lib/mnesiac/store_manager.ex
@@ -70,6 +70,7 @@ defmodule Mnesiac.StoreManager do
           Logger.info(fn ->
             "[mnesiac:#{Node.self()}] #{inspect(data_mapper)}: data found on both sides, copy aborted."
           end)
+
           apply(data_mapper, :resolve_conflict, [cluster_node])
       end
     end)

--- a/lib/mnesiac/store_manager.ex
+++ b/lib/mnesiac/store_manager.ex
@@ -67,10 +67,6 @@ defmodule Mnesiac.StoreManager do
           {:error, :no_remote_data_to_copy}
 
         {_local, _remote} ->
-          Logger.info(fn ->
-            "[mnesiac:#{Node.self()}] #{inspect(data_mapper)}: data found on both sides, copy aborted."
-          end)
-
           apply(data_mapper, :resolve_conflict, [cluster_node])
       end
     end)

--- a/test/support/example_store.ex
+++ b/test/support/example_store.ex
@@ -2,9 +2,11 @@ defmodule Mnesiac.ExampleStore do
   @moduledoc false
   require Record
 
+  use Mnesiac.Store
+
   Record.defrecord(
     :example,
-    ExampleStore,
+    __MODULE__,
     id: nil,
     topic_id: nil,
     event: nil
@@ -18,16 +20,15 @@ defmodule Mnesiac.ExampleStore do
             event: String.t()
           )
 
-  def init_store do
-    :mnesia.create_table(
-      ExampleStore,
-      attributes: example() |> example() |> Keyword.keys(),
-      index: [:topic_id],
-      disc_copies: [Node.self()]
-    )
-  end
+  @impl true
+  def store_options, do: [
+    attributes: example() |> example() |> Keyword.keys(),
+    index: [:topic_id],
+    ram_copies: [Node.self()]
+  ]
 
+  @impl true
   def copy_store do
-    :mnesia.add_table_copy(ExampleStore, Node.self(), :disc_copies)
+    :mnesia.add_table_copy(__MODULE__, Node.self(), :disc_copies)
   end
 end

--- a/test/support/example_store.ex
+++ b/test/support/example_store.ex
@@ -21,11 +21,12 @@ defmodule Mnesiac.ExampleStore do
           )
 
   @impl true
-  def store_options, do: [
-    attributes: example() |> example() |> Keyword.keys(),
-    index: [:topic_id],
-    ram_copies: [Node.self()]
-  ]
+  def store_options,
+    do: [
+      attributes: example() |> example() |> Keyword.keys(),
+      index: [:topic_id],
+      ram_copies: [Node.self()]
+    ]
 
   @impl true
   def copy_store do


### PR DESCRIPTION
This partially addresses this issue: https://github.com/beardedeagle/mnesiac/issues/8

I'd added a behaviour for stores as well that give a default implementation of init_store and copy_store

## Fixes/Addresses

https://github.com/beardedeagle/mnesiac/issues/8

#

## Change proposed in this pull request

This adds a behaviour, `Mnesiac.Store` which includes a default implementation of `init_store/0` and `copy_store/0`. Here's an updated ExampleStore which uses it:

```defmodule Mnesiac.ExampleStore do
  @moduledoc false
  require Record

  use Mnesiac.Store

  Record.defrecord(
    :example,
    __MODULE__,
    id: nil,
    topic_id: nil,
    event: nil
  )

  @type example ::
          record(
            :example,
            id: String.t(),
            topic_id: String.t(),
            event: String.t()
          )

  @impl true
  def store_options,
    do: [
      attributes: example() |> example() |> Keyword.keys(),
      index: [:topic_id],
      ram_copies: [Node.self()]
    ]

  @impl true
  def copy_store do
    :mnesia.add_table_copy(__MODULE__, Node.self(), :disc_copies)
  end
end
```

I've also augmented copy_tables in the Store Manager to inspect the local and remote nodes before attempting to copy, as discussed in the issue linked above. 

At the moment it aborts the copy in the event that there's no table on the remote node or data on both nodes. there is a `resolve_conflict/1` callback but there's no default implementation there yet.

## Check list

<!-- ⚠️ Failure to follow this checklist will result in your pull request being closed. ⚠️ -->

- [Y] All new code is formatted.
- [Y] All new code is documented.
- [Y] All new code passed static analysis/linter checks.
- [~] Added tests to ensure coverage of new code.
- [Y] All tests passed.

## Additional info


