### PR TITLE
Fix log message related crash ("protocol String.Chars not implemented...")

### DIFF
--- a/lib/mnesiac.ex
+++ b/lib/mnesiac.ex
@@ -55,7 +55,7 @@ defmodule Mnesiac do
       :ok
     else
       {:error, reason} ->
-        Logger.debug(fn -> "[mnesiac:#{node()}] #{reason}" end)
+        Logger.debug(fn -> "[mnesiac:#{node()}] #{inspect(reason)}" end)
         {:error, reason}
     end
   end

--- a/lib/mnesiac.ex
+++ b/lib/mnesiac.ex
@@ -35,7 +35,7 @@ defmodule Mnesiac do
       :ok
     else
       {:error, reason} ->
-        Logger.debug(fn -> "[mnesiac:#{node()}] #{reason}" end)
+        Logger.debug(fn -> "[mnesiac:#{node()}] #{inspect(reason)}" end)
         {:error, reason}
     end
   end


### PR DESCRIPTION
## Fixes/Addresses

Sometimes `reason` is a tuple here, resulting in crashes like:

```
protocol String.Chars not implemented for {:failed_to_connect_node, :"foo@computer-name"}
```

Wrapped it in `inspect` to fix

#

## Change proposed in this pull request

n/a

## Check list

<!-- ⚠️ Failure to follow this checklist will result in your pull request being closed. ⚠️ -->

- [x] All new code is formatted.
- [ ] All new code is documented.
- [x] All new code passed static analysis/linter checks.
- [ ] Added tests to ensure coverage of new code.
- [x] All tests passed.

## Additional info

n/a
