### PR TITLE
Use table_load_timeout for get_table_cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[0.3.11]] - 2023-05-04
-### ADDED
+## [[0.3.12]] - 2023-05-06
+### Changed
+- Changed `get_table_cookies/1` and `get_table_cookies/2` to utilize `table_load_timeout/0` for `:rpc.call/5` calls.
+
+## [[0.3.11]] - 2023-05-06
+### Added
 - Added test to ensure `get_table_cookies/1` returns error when node is not reachable.
 
 ### Fixed
@@ -17,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated dependencies.
 - Updated GitHub repo files.
 
-### FIXED
+### Fixed
 - Updated `get_table_cookies/1` to use `:local_tables` instead of `:tables` to properly identify table copies that don't exist locally to a given node, closes #84.
 
 ## [[0.3.9]] - 2021-02-21
@@ -108,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[0.3.12]: https://github.com/beardedeagle/mnesiac/compare/v0.3.11...v0.3.12
 [0.3.11]: https://github.com/beardedeagle/mnesiac/compare/v0.3.10...v0.3.11
 [0.3.10]: https://github.com/beardedeagle/mnesiac/compare/v0.3.9...v0.3.10
 [0.3.9]: https://github.com/beardedeagle/mnesiac/compare/v0.3.8...v0.3.9

--- a/lib/mnesiac/store_manager.ex
+++ b/lib/mnesiac/store_manager.ex
@@ -126,7 +126,7 @@ defmodule Mnesiac.StoreManager do
   This function returns a map of tables and their cookies.
   """
   def get_table_cookies(node \\ node()) do
-    case :rpc.call(node, :mnesia, :system_info, [:local_tables], 5_000) do
+    case :rpc.call(node, :mnesia, :system_info, [:local_tables], table_load_timeout()) do
       {:badrpc, reason} ->
         {:error, reason}
 
@@ -137,7 +137,7 @@ defmodule Mnesiac.StoreManager do
 
   defp get_table_cookies(node, tables) do
     Enum.reduce_while(tables, {:ok, %{}}, fn table, {:ok, acc} ->
-      case :rpc.call(node, :mnesia, :table_info, [table, :cookie], 5_000) do
+      case :rpc.call(node, :mnesia, :table_info, [table, :cookie], table_load_timeout()) do
         {:badrpc, reason} ->
           {:halt, {:error, reason}}
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Mnesiac.MixProject do
   def project do
     [
       app: :mnesiac,
-      version: "0.3.11",
+      version: "0.3.12",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],


### PR DESCRIPTION
## Fixes/Addresses

N/A

## Change proposed in this pull request

- Changed `get_table_cookies/1` and `get_table_cookies/2` to utilize `table_load_timeout/0` for `:rpc.call/5` calls.

## Check list

- [X] If applicable, all new code is formatted.
- [X] If applicable, all new code is documented.
- [X] If applicable, all new code passed static analysis/linter checks.
- [X] If applicable, added tests to ensure coverage of new code.
- [X] If applicable, all tests passed.

## Additional info

N/A
